### PR TITLE
add the format data logic

### DIFF
--- a/src/format.php
+++ b/src/format.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App;
+
+class Formatter
+{
+    /**
+     * Format a date string
+     */
+    public static function formatDate($date, $format = 'Y-m-d'): string
+    {
+        if ($date instanceof \DateTime) {
+            return $date->format($format);
+        }
+        return \DateTime::createFromFormat('Y-m-d H:i:s', $date)->format($format);
+    }
+
+    /**
+     * Format a string to uppercase
+     */
+    public static function formatUpper($string): string
+    {
+        return strtoupper($string);
+    }
+
+    /**
+     * Format a string to lowercase
+     */
+    public static function formatLower($string): string
+    {
+        return strtolower($string);
+    }
+
+    /**
+     * Format a number with thousand separators
+     */
+    public static function formatNumber($number, $decimals = 0): string
+    {
+        return number_format($number, $decimals, '.', ',');
+    }
+
+    /**
+     * Format currency
+     */
+    public static function formatCurrency($amount, $currency = 'USD'): string
+    {
+        return $currency . ' ' . number_format($amount, 2, '.', ',');
+    }
+
+    /**
+     * Trim and capitalize first letter of each word
+     */
+    public static function formatTitle($string): string
+    {
+        return ucwords(trim($string));
+    }
+
+    /**
+     * Format a string to slug format
+     */
+    public static function formatSlug($string): string
+    {
+        return strtolower(preg_replace('/[^a-z0-9]+/i', '-', trim($string)));
+    }
+}


### PR DESCRIPTION
This pull request introduces a new utility class, `Formatter`, in the `App` namespace. The `Formatter` class provides a collection of static methods for common formatting tasks such as dates, strings, numbers, and currencies.

New formatting utilities (`src/format.php`):

* Added `Formatter::formatDate` for formatting date strings or `DateTime` objects into a specified format.
* Added string formatting methods: `formatUpper` (uppercase), `formatLower` (lowercase), `formatTitle` (capitalize each word), and `formatSlug` (generate URL-friendly slugs).
* Added number formatting with `formatNumber` (thousand separators) and `formatCurrency` (currency formatting with symbol and decimals).